### PR TITLE
Contact Page Improvements

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -21,7 +21,7 @@
 * {
   margin: 0;
   padding: 0;
-  font-family: 'Montserrat-Regular', sans-serif;
+  font-family: "Montserrat-Regular", sans-serif;
 }
 
 body {
@@ -30,9 +30,14 @@ body {
   background-color: #f7fafc;
 }
 
-.rightMost { margin-left: auto; }
+.rightMost {
+  margin-left: auto;
+}
 
-.wrapper { width: 960px; margin: 0 auto; }
+.wrapper {
+  width: 960px;
+  margin: 0 auto;
+}
 
 .multiSec {
   display: -webkit-flex;
@@ -47,7 +52,7 @@ header {
   top: 0;
   right: 0;
   left: 0;
-  background-color: rgba(19,22,80,0.6);
+  background-color: rgba(19, 22, 80, 0.6);
 }
 
 header div.wrapper {
@@ -64,7 +69,7 @@ header div.wrapper {
 header a#HSI {
   width: 160px;
   height: 60px;
-  background-image: url('../images/HSI.png');
+  background-image: url("../images/HSI.png");
   background-position: center;
   background-repeat: no-repeat;
   -webkit-background-size: 100%;
@@ -81,7 +86,7 @@ header a#menu {
   background-repeat: no-repeat;
   -webkit-background-size: cover;
   background-size: cover;
-  background-image: url('../images/menu.svg');
+  background-image: url("../images/menu.svg");
 }
 
 header nav ul {
@@ -107,7 +112,7 @@ header nav ul > li > ul {
   width: 150px;
   margin-top: 8px;
   padding: 5px 10px;
-  background-color: rgba(19,22,80,0.6);
+  background-color: rgba(19, 22, 80, 0.6);
   flex-flow: column nowrap;
 }
 
@@ -136,7 +141,6 @@ header nav ul > li a img {
   margin-left: 3px;
   display: inline-block;
   vertical-align: middle;
-
 }
 
 header nav ul > li:hover > a,
@@ -146,13 +150,13 @@ header nav ul > li a.active {
 }
 
 header nav ul > li a::after {
-  content: '';
+  content: "";
   position: absolute;
   right: 0;
   bottom: -8px;
   width: 8px;
   height: 7px;
-  background-image: url('../images/menu-underline.png');
+  background-image: url("../images/menu-underline.png");
   background-position: right bottom;
   background-repeat: no-repeat;
   -webkit-background-size: 100%;
@@ -186,7 +190,7 @@ section.capaBanner {
 section#banner.homeBanner {
   height: auto;
   min-height: 100vh;
-  background-image: url('../images/banner.jpg');
+  background-image: url("../images/banner.jpg");
 }
 
 section#banner.homeBanner h1 {
@@ -197,7 +201,7 @@ section#banner.homeBanner h1 {
 }
 
 section#banner.homeBanner h1 small {
-  font-family: 'Montserrat-ExtraLight', sans-serif;
+  font-family: "Montserrat-ExtraLight", sans-serif;
   font-size: 24px;
   font-weight: normal;
   color: #e4f3fd;
@@ -215,14 +219,16 @@ section#banner.homeBanner a {
   margin-top: 15px;
 }
 
-section#banner.aboutBanner { background-image: url('../images/aboutBanner.jpg'); }
+section#banner.aboutBanner {
+  background-image: url("../images/aboutBanner.jpg");
+}
 
 section#banner.aboutBanner h1,
 section#banner.whoweareBanner h1,
 section.capaBanner h1,
 section#banner.presBanner h1,
 section#banner.contactBanner h1 {
-  font-family: 'Montserrat-ExtraLight', sans-serif;
+  font-family: "Montserrat-ExtraLight", sans-serif;
   color: #e4f3fd;
   font-size: 32px;
   letter-spacing: 3px;
@@ -242,14 +248,18 @@ section#banner.aboutBanner h1 small span,
 section#banner.whoweareBanner h1 small span,
 section.capaBanner h1 small span,
 section#banner.presBanner h1 small span,
-section#banner.contactBanner h1 small span { color: #F9C232; }
+section#banner.contactBanner h1 small span {
+  color: #f9c232;
+}
 
 section#banner.aboutBanner h1 strong {
   font-family: "Montserrat-Bold", sans-serif;
   color: #fff;
 }
 
-section.capaBanner { background-image: url('../images/capaBanner.jpg'); }
+section.capaBanner {
+  background-image: url("../images/capaBanner.jpg");
+}
 
 section.capaBanner div.wrapper {
   position: absolute;
@@ -259,16 +269,21 @@ section.capaBanner div.wrapper {
   bottom: 0;
 }
 
+section#banner.presBanner {
+  background-image: url("../images/pressBanner.jpg");
+}
 
-section#banner.presBanner { background-image: url('../images/pressBanner.jpg'); }
+section#banner.contactBanner {
+  background-image: url("../images/contactBanner.jpg");
+}
 
-section#banner.contactBanner { background-image: url('../images/contactBanner.jpg'); }
-
-section#banner.whoweareBanner { background-image: url('../images/whoweareBanner.jpg'); }
+section#banner.whoweareBanner {
+  background-image: url("../images/whoweareBanner.jpg");
+}
 
 section#homeMid {
   width: 100%;
-  background-image: url('../images/home-bg.jpg');
+  background-image: url("../images/home-bg.jpg");
   background-position: center;
   background-repeat: no-repeat;
   -webkit-background-size: 100%;
@@ -292,7 +307,7 @@ section#homeMid {
   /*box-shadow: 0 0 8px 1px #d4d4d4;*/
 }
 
-#homeInfo div.inner { 
+#homeInfo div.inner {
   /*padding: 30px; */
 }
 
@@ -308,14 +323,14 @@ section#homeMid {
   color: #879eed;
   text-transform: uppercase;
   font-weight: normal;
-  font-family: 'Montserrat-Light', sans-serif;
+  font-family: "Montserrat-Light", sans-serif;
 }
 
 #homeInfo p {
   color: #a4a9ba;
   font-size: 15px;
   text-align: center;
-  font-family: 'Montserrat-Light', sans-serif;
+  font-family: "Montserrat-Light", sans-serif;
 }
 
 section#serviceSec {
@@ -336,9 +351,13 @@ section#serviceSec aside.serviceTab {
   transition: 0.2s all linear;
 }
 
-section#serviceSec aside.serviceTab:hover { background-color: #435C94; }
+section#serviceSec aside.serviceTab:hover {
+  background-color: #435c94;
+}
 
-section#serviceSec aside.serviceTab div.tabInner { margin: 40px; }
+section#serviceSec aside.serviceTab div.tabInner {
+  margin: 40px;
+}
 
 section#serviceSec aside.serviceTab span {
   display: inline-block;
@@ -364,7 +383,11 @@ section#serviceSec aside.serviceTab h3 {
   flex-flow: nowrap;
 }
 
-section#serviceSec aside.serviceTab p { font-size: 13px; margin: 15px 0; text-align: left; }
+section#serviceSec aside.serviceTab p {
+  font-size: 13px;
+  margin: 15px 0;
+  text-align: left;
+}
 
 section#serviceSec aside.serviceTab a {
   color: #9cc4ff;
@@ -382,7 +405,8 @@ section#quote {
 }
 
 section#quote aside {
-  width: 50%; color: #fff;
+  width: 50%;
+  color: #fff;
   height: auto;
   min-height: 350px;
   background-position: center;
@@ -400,10 +424,12 @@ section#quote aside div {
   position: relative;
 }
 
-section#quote aside:first-child { background-image: url('../images/testimonial1.jpg'); }
+section#quote aside:first-child {
+  background-image: url("../images/testimonial1.jpg");
+}
 
 section#quote aside:last-child {
-  background-image: url('../images/testimonial2.jpg');
+  background-image: url("../images/testimonial2.jpg");
   display: -webkit-flex;
   display: -ms-flex;
   display: flex;
@@ -416,7 +442,7 @@ section#quote aside span {
   width: 50px;
   height: 50px;
   margin-top: 60px;
-  background-image: url('../images/testimonial.png');
+  background-image: url("../images/testimonial.png");
   background-position: center;
   background-repeat: no-repeat;
   -webkit-background-size: cover;
@@ -425,16 +451,22 @@ section#quote aside span {
 }
 
 section#quote aside p {
-  font-size: 18px; margin: 10px 0;
+  font-size: 18px;
+  margin: 10px 0;
 }
 
-section#quote aside p em { font-family: 'Montserrat-Light', sans-serif; }
+section#quote aside p em {
+  font-family: "Montserrat-Light", sans-serif;
+}
 
-section#quote aside p strong { font-size: 13px; text-transform: uppercase; }
+section#quote aside p strong {
+  font-size: 13px;
+  text-transform: uppercase;
+}
 
-
-
-section#testiSec { padding: 80px 0; }
+section#testiSec {
+  padding: 80px 0;
+}
 
 section#testiSec h2 {
   color: #fac333;
@@ -470,13 +502,15 @@ section#testimonial aside.testiTab span {
   background-color: #f6f6f6;
 }
 
-section#testimonial aside.testiTab article {  padding: 20px; }
+section#testimonial aside.testiTab article {
+  padding: 20px;
+}
 
 section#testimonial aside.testiTab article p {
   color: #606d74;
   font-size: 12px;
   margin: 8px 0;
-  font-family: 'Montserrat-Light', sans-serif;
+  font-family: "Montserrat-Light", sans-serif;
 }
 
 section#testimonial aside.testiTab article p strong {
@@ -498,23 +532,24 @@ section#clients h2 {
   text-align: center;
 }
 
-
 section#mission aside,
 section#values aside,
 section#aboutQlty aside,
 section#contractWho aside {
   width: 50%;
-  background-image: url('../images/side-image.jpg');
+  background-image: url("../images/side-image.jpg");
   background-position: center;
   background-repeat: no-repeat;
   -webkit-background-size: cover;
   background-size: cover;
 }
 
-section#aboutQlty aside { background-image: url('../images/side-image1.jpg'); }
+section#aboutQlty aside {
+  background-image: url("../images/side-image1.jpg");
+}
 
 section#contractWho aside {
-  background-image: url('../images/who-side-image.jpg');
+  background-image: url("../images/who-side-image.jpg");
   text-align: right;
 }
 
@@ -534,16 +569,20 @@ section#contractWho article {
 }
 
 section#mission article div.inner,
-section#values  div.inner,
+section#values div.inner,
 ul.values li div.inner,
 section#aboutQlty article div.inner,
 section#contractWho aside div.inner,
-section#contractWho article div.inner { padding: 85px 40px; }
+section#contractWho article div.inner {
+  padding: 85px 40px;
+}
 
-section#values div.inner { text-align: center; }
+section#values div.inner {
+  text-align: center;
+}
 
 section#mission article h2,
-section#values  h2,
+section#values h2,
 section#aboutQlty article h2,
 section#contractWho article h2 {
   color: #444969;
@@ -563,7 +602,7 @@ section#contractWho article p,
 section.blogBanner article p,
 .blog-list li,
 section.blogBanner p {
-  font-family: 'Montserrat-Light', sans-serif;
+  font-family: "Montserrat-Light", sans-serif;
   font-size: 14px;
   color: #444969;
   line-height: 25px;
@@ -575,12 +614,16 @@ section#mission article p,
 section#values article p,
 section#values p,
 ul.values li p,
-section#aboutQlty article p { width: 100%; }
+section#aboutQlty article p {
+  width: 100%;
+}
 
-section#values p { margin: 0 auto;; }
+section#values p {
+  margin: 0 auto;
+}
 
 section#aboutTest {
-  background-image: url('../images/about-testimonial.jpg');
+  background-image: url("../images/about-testimonial.jpg");
   background-position: center;
   -webkit-background-size: cover;
   background-size: cover;
@@ -594,7 +637,9 @@ section#aboutTest article {
 section#aboutTest article div.inner,
 section.capRight article div.inner,
 section.capLeft article div.inner,
-section#contactInfo article div.inner { padding: 100px 40px; }
+section#contactInfo article div.inner {
+  padding: 100px 40px;
+}
 
 section#aboutTest article h2 {
   color: #fff;
@@ -604,7 +649,7 @@ section#aboutTest article h2 {
 
 section#aboutTest article p {
   color: #bbbfe8;
-  font-family: 'Montserrat-Light', sans-serif;
+  font-family: "Montserrat-Light", sans-serif;
   font-size: 14px;
   line-height: 25px;
 }
@@ -621,12 +666,14 @@ section#contactInfo address {
   justify-content: center;
 }
 
-section.capLeft aside.mobView { display: none; }
+section.capLeft aside.mobView {
+  display: none;
+}
 
 section#aboutTest aside span {
   width: 200px;
   height: 200px;
-  background-image: url('../images/Shubhi_hi-res.jpg');
+  background-image: url("../images/Shubhi_hi-res.jpg");
   border-radius: 50%;
   background-position: center;
   background-repeat: no-repeat;
@@ -641,14 +688,16 @@ section#aboutTest aside h2 {
 }
 
 section#aboutTest aside p {
-  color: #5B97E4;
-  font-family: 'Montserrat-Light', sans-serif;
+  color: #5b97e4;
+  font-family: "Montserrat-Light", sans-serif;
 }
 
-section.capRight { background-color: #fff; }
+section.capRight {
+  background-color: #fff;
+}
 
 section.capLeft {
-  background-color: #F9F9FA;
+  background-color: #f9f9fa;
   background-position: center;
   background-repeat: no-repeat;
   -webkit-background-size: cover;
@@ -656,11 +705,17 @@ section.capLeft {
   background-attachment: fixed;
 }
 
-section.capLeft.bioInfo { background-image: url('../images/cap1.jpg'); }
+section.capLeft.bioInfo {
+  background-image: url("../images/cap1.jpg");
+}
 
-section.capLeft.reguComp { background-image: url('../images/cap2.jpg'); }
+section.capLeft.reguComp {
+  background-image: url("../images/cap2.jpg");
+}
 
-section.capLeft.softDev { background-image: url('../images/cap3.jpg'); }
+section.capLeft.softDev {
+  background-image: url("../images/cap3.jpg");
+}
 
 section.capRight aside,
 section.capLeft aside {
@@ -675,20 +730,30 @@ section.capLeft aside {
 }
 
 section.capRight article,
-section.capLeft article { width: 70%; }
+section.capLeft article {
+  width: 70%;
+}
 section.capRight article h2,
 section.capLeft article h2,
 section#contactInfo article h2 {
   font-size: 22px;
-  color: #2E4962;
+  color: #2e4962;
   margin-bottom: 15px;
 }
 
-section.capLeft article h2 { color: #fff; }
+section.capLeft article h2 {
+  color: #fff;
+}
 
-section.capLeft article {text-align: left; }
+section.capLeft article {
+  text-align: left;
+}
 
-section.capLeft article p, section.capLeft article ul { margin-left: auto; color: #fff; }
+section.capLeft article p,
+section.capLeft article ul {
+  margin-left: auto;
+  color: #fff;
+}
 
 section.capRight aside span,
 section.capLeft aside span {
@@ -702,31 +767,37 @@ section.capLeft aside span {
   background-size: cover;
 }
 
-nav#presMenu { margin: 50px 0; }
+nav#presMenu {
+  margin: 50px 0;
+}
 
 nav#presMenu a {
   display: inline-block;
   padding: 0 10px 15px 10px;
-  color: #8C9AA7;
+  color: #8c9aa7;
   text-decoration: none;
-  border-bottom: #8C9AA7 solid thin;
+  border-bottom: #8c9aa7 solid thin;
 }
 
 nav#presMenu a.active {
-  color: #131F2B;
+  color: #131f2b;
   padding-bottom: 14px;
-  border-bottom: #F8C235 solid 3px;
+  border-bottom: #f8c235 solid 3px;
 }
 
-section#pressSec div.wrapper { margin: 40px auto; }
+section#pressSec div.wrapper {
+  margin: 40px auto;
+}
 
 aside.pressTab {
   width: calc(95% / 3);
   text-align: center;
-  border: #ABB7C1 solid thin;
+  border: #abb7c1 solid thin;
 }
 
-aside.pressTab:nth-child(2) { margin: 0 30px; }
+aside.pressTab:nth-child(2) {
+  margin: 0 30px;
+}
 
 aside.pressTab span {
   display: inline-block;
@@ -738,7 +809,9 @@ aside.pressTab span {
   background-size: cover;
 }
 
-aside.pressTab article { padding: 25px 15px; }
+aside.pressTab article {
+  padding: 25px 15px;
+}
 
 aside.pressTab article h3 {
   color: #000000;
@@ -746,8 +819,8 @@ aside.pressTab article h3 {
 }
 
 aside.pressTab article p {
-  font-family: 'Montserrat-Light', sans-serif;
-  color: #ABB7C1;
+  font-family: "Montserrat-Light", sans-serif;
+  color: #abb7c1;
   margin: 20px 0;
   font-size: 15px;
 }
@@ -755,7 +828,7 @@ aside.pressTab article p {
 aside.pressTab article a {
   display: inline-block;
   color: #fff;
-  background-color: #F4BF32;
+  background-color: #f4bf32;
   padding: 8px 20px;
   font-size: 14px;
   border-radius: 12px;
@@ -764,10 +837,12 @@ aside.pressTab article a {
 }
 
 section#contactInfo address,
-section#contactInfo article { width: 50%; }
+section#contactInfo article {
+  width: 50%;
+}
 
 section#contactInfo article p {
-  border-left: #FAC333 solid 4px;
+  border-left: #fac333 solid 4px;
   padding-left: 8px;
 }
 
@@ -779,7 +854,7 @@ section#contactInfo address p {
   display: flex;
   flex-flow: row nowrap;
   font-style: normal;
-  font-family: 'Montserrat-Light', sans-serif;
+  font-family: "Montserrat-Light", sans-serif;
   color: #444969;
   margin-top: 20px;
 }
@@ -794,11 +869,17 @@ section#contactInfo address p span {
   margin-right: 8px;
 }
 
-section#contactInfo address p span.ph { background-image: url('../images/phone.png'); }
+section#contactInfo address p span.ph {
+  background-image: url("../images/phone.png");
+}
 
-section#contactInfo address p span.loc { background-image: url('../images/location.png'); }
+section#contactInfo address p span.loc {
+  background-image: url("../images/location.png");
+}
 
-section#contactInfo address p span.mail { background-image: url('../images/mail.png'); }
+section#contactInfo address p span.mail {
+  background-image: url("../images/mail.png");
+}
 
 section#ourClients {
   text-align: center;
@@ -836,7 +917,10 @@ section#careers p {
   line-height: 28px;
 }
 
-section#clntLogo { padding: 30px 0; background-color: #F9F9F9; }
+section#clntLogo {
+  padding: 30px 0;
+  background-color: #f9f9f9;
+}
 
 section#contractWho aside ul li {
   width: 60%;
@@ -859,7 +943,7 @@ section#contractWho aside ul li span {
   background-position: center;
   -webkit-background-size: 100%;
   background-size: 100%;
-  background-image: url('../images/bullet-point.png');
+  background-image: url("../images/bullet-point.png");
 }
 
 section#contractWho aside ul li div h3 {
@@ -900,7 +984,7 @@ footer section div.wrapper {
 footer section a#fHSI {
   width: 200px;
   height: 80px;
-  background-image: url('../images/HSI.png');
+  background-image: url("../images/HSI.png");
   background-repeat: no-repeat;
   background-position: center;
   -webkit-background-size: 100%;
@@ -943,20 +1027,29 @@ footer section address a span {
   margin-right: 10px;
 }
 
-footer section address a samp { width: calc(100% - 30px); }
-
-footer section address a span.ph { background-image: url('../images/phone.png'); }
-
-footer section address a span.loc { background-image: url('../images/location.png'); }
-
-footer section address a span.email { background-image: url('../images/mail.png');
--webkit-background-size: 90%;
-background-size: 90%;
+footer section address a samp {
+  width: calc(100% - 30px);
+  white-space: nowrap;
 }
 
-footer section address a span.fax { background-image: url('../images/fax.png');
--webkit-background-size: 90%;
-background-size: 90%;
+footer section address a span.ph {
+  background-image: url("../images/phone.png");
+}
+
+footer section address a span.loc {
+  background-image: url("../images/location.png");
+}
+
+footer section address a span.email {
+  background-image: url("../images/mail.png");
+  -webkit-background-size: 90%;
+  background-size: 90%;
+}
+
+footer section address a span.fax {
+  background-image: url("../images/fax.png");
+  -webkit-background-size: 90%;
+  background-size: 90%;
 }
 
 footer section nav#social a {
@@ -974,32 +1067,50 @@ footer section nav#social a {
   transition: 0.2s all linear;
 }
 
-footer section nav#social a:hover { background-color: #fff; }
-
-footer section nav#social a:first-child { margin-left: 0; }
-
-footer section nav#social a.facebook { background-image: url('../images/facebook.svg'); }
-
-footer section nav#social a.twitter { background-image: url('../images/twitter.svg'); }
-
-footer section nav#social a.linkedin { background-image: url('../images/linkedin.svg'); }
-
-footer section nav#social a.rss { background-image: url('../images/rss.svg'); }
-
-@media screen
-and (max-width: 1000px)
-and (min-width: 300px) {
-  .wrapper { width: 95%; }
-  header nav ul li  { margin-left: 10px; }
-  header nav ul li a { font-size: 12px; }
+footer section nav#social a:hover {
+  background-color: #fff;
 }
 
-@media screen
-and (max-width: 700px)
-and (min-width: 300px) {
-  .multiSec { flex-flow: column nowrap; }
+footer section nav#social a:first-child {
+  margin-left: 0;
+}
 
-  header a#menu { display: block; }
+footer section nav#social a.facebook {
+  background-image: url("../images/facebook.svg");
+}
+
+footer section nav#social a.twitter {
+  background-image: url("../images/twitter.svg");
+}
+
+footer section nav#social a.linkedin {
+  background-image: url("../images/linkedin.svg");
+}
+
+footer section nav#social a.rss {
+  background-image: url("../images/rss.svg");
+}
+
+@media screen and (max-width: 1000px) and (min-width: 300px) {
+  .wrapper {
+    width: 95%;
+  }
+  header nav ul li {
+    margin-left: 10px;
+  }
+  header nav ul li a {
+    font-size: 12px;
+  }
+}
+
+@media screen and (max-width: 700px) and (min-width: 300px) {
+  .multiSec {
+    flex-flow: column nowrap;
+  }
+
+  header a#menu {
+    display: block;
+  }
 
   header nav {
     display: none;
@@ -1007,13 +1118,17 @@ and (min-width: 300px) {
     left: 0;
     right: 0;
     top: 80px;
-    background-color: rgba(19,22,80,0.6);
+    background-color: rgba(19, 22, 80, 0.6);
     text-align: center;
   }
 
-  header nav ul { flex-flow: column nowrap; }
+  header nav ul {
+    flex-flow: column nowrap;
+  }
 
-  header nav ul > li { width: 90%; }
+  header nav ul > li {
+    width: 90%;
+  }
 
   header nav ul > li a {
     font-size: 14px;
@@ -1030,16 +1145,26 @@ and (min-width: 300px) {
     width: 100%;
   }
 
-  header nav ul > li:hover > ul { position: relative; }
+  header nav ul > li:hover > ul {
+    position: relative;
+  }
 
-
-  section#banner.homeBanner { padding: 80px 0; }
-  section#serviceSec { flex-flow: row wrap; }
-  section#serviceSec aside.serviceTab { width: 200px; }
+  section#banner.homeBanner {
+    padding: 80px 0;
+  }
+  section#serviceSec {
+    flex-flow: row wrap;
+  }
+  section#serviceSec aside.serviceTab {
+    width: 200px;
+  }
   section#mission aside,
   section#values aside,
   section#aboutQlty aside,
-  section#contractWho aside { width: 100%; height: 500px; }
+  section#contractWho aside {
+    width: 100%;
+    height: 500px;
+  }
   section.capRight aside,
   section.capLeft aside {
     width: 100%;
@@ -1048,9 +1173,13 @@ and (min-width: 300px) {
     padding: 30px 0;
   }
 
-  section.capLeft aside.deskView { display: none; }
+  section.capLeft aside.deskView {
+    display: none;
+  }
 
-  section.capLeft aside.mobView { display: block; }
+  section.capLeft aside.mobView {
+    display: block;
+  }
 
   section#mission article,
   section#values article,
@@ -1060,51 +1189,104 @@ and (min-width: 300px) {
   section.capRight article,
   section.capLeft article,
   section#contactInfo address,
-  section#contactInfo article { width: 100%; }
+  section#contactInfo article {
+    width: 100%;
+  }
   section.capRight article div.inner,
-  section.capLeft article div.inner{ padding: 30px 0;  }
+  section.capLeft article div.inner {
+    padding: 30px 0;
+  }
   section#mission article h2,
   section#values article h2,
   section#aboutQlty article h2,
   section#contractWho article h2,
   section.capRight article h2,
   section.capLeft article h2,
-  section#contactInfo article h2 { text-align: center; }
+  section#contactInfo article h2 {
+    text-align: center;
+  }
   section#mission article p,
   section#values article p,
   section#aboutQlty article p,
   section.capRight article p,
   section.capLeft article p,
   section#contactInfo article p,
-  section#contractWho article p { width: 80%; margin: 0 auto; }
-  section#contactInfo address p { margin: 10px auto; }
-  section#aboutTest aside { padding-bottom: 30px; }
+  section#contractWho article p {
+    width: 80%;
+    margin: 0 auto;
+  }
+  section#contactInfo address p {
+    margin: 10px auto;
+  }
+  section#aboutTest aside {
+    padding-bottom: 30px;
+  }
   section.capRight article p,
-  section.capLeft article p {text-align: center; }
-  aside.pressTab { width: 100%; margin: 20px auto !important; }
-  footer section div.wrapper { flex-flow: column nowrap; }
-  footer section address { margin: 30px auto; }
-  footer section nav#social { margin: 0 auto; }
+  section.capLeft article p {
+    text-align: center;
+  }
+  aside.pressTab {
+    width: 100%;
+    margin: 20px auto !important;
+  }
+  footer section div.wrapper {
+    flex-flow: column nowrap;
+  }
+  footer section address {
+    margin: 30px auto;
+  }
+  footer section nav#social {
+    margin: 0 auto;
+  }
+
+  section#contactInfo address {
+    width: 100%;
+    margin-top: 50px;
+    padding-left: 10%;
+  }
+
+  section#contactInfo article div.inner {
+    padding: 50px 40px;
+  }
 }
 
-@media screen
-and (max-width: 500px)
-and (min-width: 300px) {
-  section#banner.homeBanner h1 { font-size: 25px; }
-  section#banner.homeBanner h1 small { font-size: 16px; }
-  section#banner.homeBanner a { padding: 8px 20px; }
-  section#quote { flex-flow: column nowrap; }
-  section#quote aside { width: 100%; }
-  section#serviceSec aside.serviceTab { width: 100%; }
+@media screen and (max-width: 500px) and (min-width: 300px) {
+  section#banner.homeBanner h1 {
+    font-size: 25px;
+  }
+  section#banner.homeBanner h1 small {
+    font-size: 16px;
+  }
+  section#banner.homeBanner a {
+    padding: 8px 20px;
+  }
+  section#quote {
+    flex-flow: column nowrap;
+  }
+  section#quote aside {
+    width: 100%;
+  }
+  section#serviceSec aside.serviceTab {
+    width: 100%;
+  }
   section#testimonial,
-  footer section address { flex-flow: column nowrap; }
-  footer section address a { margin: 10px auto; text-align: left; }
-  section#testimonial aside.testiTab { width: 90%; margin: 10px auto; }
+  footer section address {
+    flex-flow: column nowrap;
+  }
+  footer section address a {
+    margin: 10px auto;
+    text-align: left;
+  }
+  section#testimonial aside.testiTab {
+    width: 90%;
+    margin: 10px auto;
+  }
 
   section#mission article div.inner,
   section#values div.inner,
-  ul.values li div.inner { padding: 30px 10px; }
-
+  ul.values li div.inner {
+    padding: 30px 10px;
+  }
 }
 
 ul.values {
@@ -1137,39 +1319,40 @@ ul.values li {
 
 ul.values li h3 {
   font-size: 18px;
-  font-family: 'Montserrat-Light', sans-serif;
+  font-family: "Montserrat-Light", sans-serif;
   margin-bottom: 10px;
   color: #fff;
 }
 
-ul.values li p { color: #fff; }
+ul.values li p {
+  color: #fff;
+}
 
 ul.values li:first-child {
-  background-color: rgba(99,42,122,0.8);
+  background-color: rgba(99, 42, 122, 0.8);
 }
 ul.values li:nth-child(2) {
-  background-color: rgba(55,60,143,0.8);
+  background-color: rgba(55, 60, 143, 0.8);
 }
 ul.values li:nth-child(3) {
-  background-color: rgba(128,55,133,0.8);
+  background-color: rgba(128, 55, 133, 0.8);
 }
 ul.values.snd li:nth-child(1) {
-  background-color: rgba(246,202,58,0.8);
+  background-color: rgba(246, 202, 58, 0.8);
 }
 
 ul.values.snd li:nth-child(1) h3,
-ul.values.snd li:nth-child(1) p { color: #686868; }
+ul.values.snd li:nth-child(1) p {
+  color: #686868;
+}
 
 ul.values.snd li:nth-child(2) {
-  background-color: rgba(28,60,120,0.8);
+  background-color: rgba(28, 60, 120, 0.8);
 }
-
 
 ul li a {
- color: #ffffff;
+  color: #ffffff;
 }
-
-
 
 .blogBanner {
   margin-top: 20px;
@@ -1187,14 +1370,15 @@ ul li a {
 }
 
 section#banner.blogBanner h1 {
-  color: #00000;
+  color: #000000;
   font-size: 47px;
   letter-spacing: 0px;
   font-weight: bold;
 }
 
-section#banner.blogBanner, section#banner.blogBanner.wrapper  {
-  font-family: 'Montserrat-Light', sans-serif
+section#banner.blogBanner,
+section#banner.blogBanner.wrapper {
+  font-family: "Montserrat-Light", sans-serif;
 }
 
 .center {
@@ -1211,38 +1395,45 @@ section#banner.blogBanner, section#banner.blogBanner.wrapper  {
 
 .author {
   font-size: 12px;
-  color: #00000;
+  color: #000000;
 }
 
 .timeline {
-    display: grid;
-    grid-column-gap: .75em;
-    grid-row-gap: .75em;
-    grid-template-columns: 1fr;
-    grid-auto-flow: row dense;
-    align-content: start;
-    margin: 0 0 2em 0;
-    padding: 0;
-  }
+  display: grid;
+  grid-column-gap: 0.75em;
+  grid-row-gap: 0.75em;
+  grid-template-columns: 1fr;
+  grid-auto-flow: row dense;
+  align-content: start;
+  margin: 0 0 2em 0;
+  padding: 0;
+}
 
- .timeline li {
-       display: block;
-    overflow: hidden;
-    width: 100%;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -ms-box-sizing: border-box;
-    box-sizing: border-box;
-    margin: 0 1% 2em 1%;
-    padding: 1em;
-    min-height: 24em;
-    -webkit-transition: all .24s ease-in-out;
-    -moz-transition: all .2s ease-in-out;
-    -o-transition: all .2s ease-in-out;
-    transition: all .2s ease-in-out;
-    opacity: .95;
-    background: rgba(0,0,0,0.02);
-    padding: 1em;
-    list-style: none;
- } 
+.timeline li {
+  display: block;
+  overflow: hidden;
+  width: 100%;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
+  margin: 0 1% 2em 1%;
+  padding: 1em;
+  min-height: 24em;
+  -webkit-transition: all 0.24s ease-in-out;
+  -moz-transition: all 0.2s ease-in-out;
+  -o-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  opacity: 0.95;
+  background: rgba(0, 0, 0, 0.02);
+  padding: 1em;
+  list-style: none;
+}
 
+#mapSec {
+  width: 100%;
+  height: 350px;
+  background: url("../images/map - use google map plugin.png") center no-repeat;
+  overflow: hidden;
+  background-color: #e4e7ee;
+}

--- a/contact.html
+++ b/contact.html
@@ -63,9 +63,7 @@
         </div>
       </article>
     </section>
-    <section id="mapSec">
-      <img src="assets/images/map - use google map plugin.png" alt="">
-    </section>
+    <section id="mapSec"></section>
     <footer>
       <section>
         <div class="wrapper">


### PR DESCRIPTION
   - Improve contact info alignment on sub-700px screens
   - Center map image on all widths
   - Safari: Fix awkward wrapping of phone/fax numbers in footer
   - Linter reformatted CSS

Before
![contact-1-before](https://user-images.githubusercontent.com/2592907/65032184-ea428980-d8ff-11e9-93c1-b004dabf97ae.png)

![map-and-footer-phone-1-before](https://user-images.githubusercontent.com/2592907/65032208-f3335b00-d8ff-11e9-9122-8ca1a3adf8cf.png)

After
![contact-2-after](https://user-images.githubusercontent.com/2592907/65032196-ee6ea700-d8ff-11e9-9c2e-4bf99daf3ba3.png)
![map-and-footer-phone-2-after](https://user-images.githubusercontent.com/2592907/65032220-f62e4b80-d8ff-11e9-80ec-7d45e148cc63.png)
